### PR TITLE
Test new relative autorefs syntax

### DIFF
--- a/src/foo/src/foo/main.py
+++ b/src/foo/src/foo/main.py
@@ -8,6 +8,8 @@ class A(BaseModel):
     """
     This is an example of a documented Pydantic model.
 
+    [foo.main.A.x][] should give the same link as [.x][foo.main.A.x]
+
     Attributes:
         x: An example number.
         y: An example string.


### PR DESCRIPTION
This PR adds a docstring that will be used to test the new autorefs syntax works.

The issue is being discussed here:

- https://github.com/mkdocstrings/python/issues/27#issuecomment-1890398753

A PR has been started to submit this feature to autorefs:

- https://github.com/mkdocstrings/autorefs/pull/37